### PR TITLE
Add 'going beyond the example' to repo.

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Additionallly, there exist:
 - `metis.config.yml` - a file telling Skafos how to execute the jobs in this project
 - `requirements.txt` - a file telling Skafos the project's dependencies
 - `save_models.py` - a helper module to save the core ml model to Skafos
+- `images_in_turicreate.ipynb` - a notebook detailing how Turi Create likes to handle image data.
 
 ## Further notes:
 - To get this to run, the model required training data. The training data for this example comes from an open source data set from Caltech's Computer Vision dept which can be found [here](http://www.vision.caltech.edu/Image_Datasets/Caltech101/101_ObjectCategories.tar.gz)

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Additionallly, there exist:
 - For retraining this image similarity model on new data, we highly recommend doing it on a GPU. As benchmarks, we've found that training this Turi Create image similarity model takes about 60 minutes on a GPU and about 1.5 days on Skafos with 6 CPU's and 10G of memory. Training will take considerably more time locally using only CPU. GPU support on Skafos is currently in development and will be coming soon.
 
 ## Going beyond the example:
-- Turi Create has built in model evaluation and prediction techniques. We've included some of the functions below but for more detailed description, refer to Turi Create's [documentation](https://apple.github.io/turicreate/docs/userguide/image_similarity/).
+- Turi Create has built-in model evaluation and prediction techniques. We've included some of the functions below but for more detailed description, refer to Turi Create's [documentation](https://apple.github.io/turicreate/docs/userguide/image_similarity/).
 
 
 #### Querying the model

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Additionallly, there exist:
 - For retraining this image similarity model on new data, we highly recommend doing it on a GPU. As benchmarks, we've found that training this Turi Create image similarity model takes about 60 minutes on a GPU and about 1.5 days on Skafos with 6 CPU's and 10G of memory. Training will take considerably more time locally using only CPU. GPU support on Skafos is currently in development and will be coming soon.
 
 ## Going beyond the example:
+- If you wish to incorporate your own data, check out `images_in_turicreate.ipynb`. It will detail the format you should have your data. It also includes some helper functions that might help you.
 - Turi Create has built-in model evaluation and prediction techniques. We've included some of the functions below but for more detailed description, refer to Turi Create's [documentation](https://apple.github.io/turicreate/docs/userguide/image_similarity/).
 
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Additionallly, there exist:
 - For retraining this image similarity model on new data, we highly recommend doing it on a GPU. As benchmarks, we've found that training this Turi Create image similarity model takes about 60 minutes on a GPU and about 1.5 days on Skafos with 6 CPU's and 10G of memory. Training will take considerably more time locally using only CPU. GPU support on Skafos is currently in development and will be coming soon.
 
 ## Going beyond the example:
-- If you wish to incorporate your own data, check out `images_in_turicreate.ipynb`. It will detail the format you should have your data. It also includes some helper functions that might help you.
+- If you wish to incorporate your own data, check out `images_in_turicreate.ipynb`. It will detail the format you should have your data in. It also includes several helper functions that might help you get your data into the Turi Create framework.
 - Turi Create has built-in model evaluation and prediction techniques. We've included some of the functions below but for more detailed description, refer to Turi Create's [documentation](https://apple.github.io/turicreate/docs/userguide/image_similarity/).
 
 

--- a/README.md
+++ b/README.md
@@ -19,3 +19,25 @@ Additionallly, there exist:
 ## Further notes:
 - To get this to run, the model required training data. The training data for this example comes from an open source data set from Caltech's Computer Vision dept which can be found [here](http://www.vision.caltech.edu/Image_Datasets/Caltech101/101_ObjectCategories.tar.gz)
 - For retraining this image similarity model on new data, we highly recommend doing it on a GPU. As benchmarks, we've found that training this Turi Create image similarity model takes about 60 minutes on a GPU and about 1.5 days on Skafos with 6 CPU's and 10G of memory. Training will take considerably more time locally using only CPU. GPU support on Skafos is currently in development and will be coming soon.
+
+## Going beyond the example:
+- Turi Create has built in model evaluation and prediction techniques. We've included some of the functions below but for more detailed description, refer to Turi Create's [documentation](https://apple.github.io/turicreate/docs/userguide/image_similarity/).
+
+
+#### Querying the model
+For the Image Similarity model, this includes the ability to query the model and find the k most similar images. This can be done by running:
+```python
+
+# query the model for the ten most similar images to the first 10 images
+query_results = model.query(reference_data[0:10], k=10)
+query_results.head()
+
+```
+
+#### Rendering and Exploring Images
+
+```python
+# assuming our training data is called reference_data
+reference_data.explore() # opens a window to explore our images
+
+```

--- a/images_in_turicreate.ipynb
+++ b/images_in_turicreate.ipynb
@@ -1,0 +1,175 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# **Getting Images into TuriCreate framework**\n",
+    "Getting images into Turi Create to build a model off of, whether that be an image classifer, image similarity or style transfer model, can be very easy, if you work within the Turi Create framework a certain way. To show you how to do this with your data, we used the popular CIFAR-10 dataset which can be downloaded [here](https://www.cs.toronto.edu/~kriz/cifar.html). Make sure to download the python batches. \n",
+    "\n",
+    "**TL;DR** Turi Create likes to load images from a directory where you pass the directory to the function `tc.load_images('directory_name')`. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from PIL import Image\n",
+    "import pandas as pd; import numpy as np; \n",
+    "import turicreate as tc\n",
+    "import pickle; import os"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Why all this code? See https://github.com/apple/turicreate/issues/119\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# cifar images come in 'batches' that are pickle files, we use this helper to load the batches\n",
+    "def unpickle(file):\n",
+    "    with open(file, 'rb') as fo:\n",
+    "        _batch = pickle.load(fo, encoding='bytes')\n",
+    "    return _batch\n",
+    "\n",
+    "# this was written to write the image to local file\n",
+    "# Loading in-memory images to a Turi Create SFrame is not easy, loading from file easy \n",
+    "def save_cifar_image(img, img_name, folder):\n",
+    "    try:\n",
+    "        img_reshaped = np.transpose(np.reshape(img, (3, 32,32)), (1,2,0))\n",
+    "        image = Image.fromarray(img_reshaped.astype(np.int8), 'RGB')\n",
+    "        image.save(f\"{folder}/{img_name.decode('utf-8')}\")\n",
+    "        return {'success' : True}\n",
+    "    except Exception as e:\n",
+    "        return {'success' : False}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### **Load the data**\n",
+    "Prior to this, make sure you've downloaded and extracted the **cifar-10-batches-py** from the CIFAR-10 website linked [here](https://www.cs.toronto.edu/~kriz/cifar.html)\n",
+    "- We create our own master batch\n",
+    "- Load each batch pickle file\n",
+    "- Store them in our own object"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# iterate over the batches, storing the image data and file names\n",
+    "master_batch = {'data': [], 'filenames' : []}\n",
+    "for i in range(5):\n",
+    "    batch = unpickle(f\"./cifar-10-batches-py/data_batch_{i+1}\")\n",
+    "    # append batch data and filenames to our master batch\n",
+    "    master_batch['data'] += list(batch[b'data'])\n",
+    "    master_batch['filenames'] += list(batch[b'filenames'])\n",
+    "\n",
+    "    "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### **Save the data to a folder**\n",
+    "We take the object we created from loading the data and save it to a folder titled **cifar-10**."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# iterate over all images in master batch, saving to a folder titled cifar-10\n",
+    "write_results = []\n",
+    "for i in range(len(master_batch['data'])):\n",
+    "    # we save the images to file, keeping track of successes and failures\n",
+    "    write_results.append(save_cifar_image(master_batch['data'][i], master_batch['filenames'][i], './cifar-10')['success'])\n",
+    "\n",
+    "print(f\"Write success for {100 * (np.sum(write_results)/len(write_results))} % of results\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### **Load into Turi Create**\n",
+    "We load the images using Turi Create's built in `tc.load_images` function."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cifar = tc.load_images('cifar-10') # turi create recursively loads all the images in 'cifar-10' and loads them into an SFrame"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# create a label column based on the path\n",
+    "cifar['label'] = cifar['path'].apply(lambda x: '_'.join(x.split(\"/\")[-1].split(\"_\")[0:-2]))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### **Fit a model**\n",
+    "Building the model is extremely simple once you've loaded the data. Both the concepts and the implementation of image similarity and image classification models are very similar. The only thing that differs is the image classification model requires a target column name"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# build an image sim\n",
+    "image_classifier = tc.image_classifier.create(cifar, target='label')\n",
+    "image_similarity = tc.image_similarity.create(cifar)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/images_in_turicreate.ipynb
+++ b/images_in_turicreate.ipynb
@@ -12,7 +12,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -31,7 +31,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -66,7 +66,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -91,12 +91,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Write success for 100.0 % of results\n"
+     ]
+    }
+   ],
    "source": [
     "# iterate over all images in master batch, saving to a folder titled cifar-10\n",
     "write_results = []\n",
+    "os.makedir(\"cifar-10\")\n",
     "for i in range(len(master_batch['data'])):\n",
     "    # we save the images to file, keeping track of successes and failures\n",
     "    write_results.append(save_cifar_image(master_batch['data'][i], master_batch['filenames'][i], './cifar-10')['success'])\n",
@@ -114,7 +123,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -123,7 +132,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -146,8 +155,8 @@
    "outputs": [],
    "source": [
     "# build an image sim\n",
-    "image_classifier = tc.image_classifier.create(cifar, target='label')\n",
-    "image_similarity = tc.image_similarity.create(cifar)"
+    "# image_classifier = tc.image_classifier.create(cifar, target='label')\n",
+    "# image_similarity = tc.image_similarity.create(cifar)"
    ]
   }
  ],

--- a/images_in_turicreate.ipynb
+++ b/images_in_turicreate.ipynb
@@ -105,7 +105,7 @@
    "source": [
     "# iterate over all images in master batch, saving to a folder titled cifar-10\n",
     "write_results = []\n",
-    "os.makedir(\"cifar-10\")\n",
+    "os.mkdir(\"cifar-10\")\n",
     "for i in range(len(master_batch['data'])):\n",
     "    # we save the images to file, keeping track of successes and failures\n",
     "    write_results.append(save_cifar_image(master_batch['data'][i], master_batch['filenames'][i], './cifar-10')['success'])\n",

--- a/images_in_turicreate.ipynb
+++ b/images_in_turicreate.ipynb
@@ -4,8 +4,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# **Getting Images into TuriCreate framework**\n",
-    "Getting images into Turi Create to build a model off of, whether that be an image classifer, image similarity or style transfer model, can be very easy, if you work within the Turi Create framework a certain way. To show you how to do this with your data, we used the popular CIFAR-10 dataset which can be downloaded [here](https://www.cs.toronto.edu/~kriz/cifar.html). Make sure to download the python batches. \n",
+    "# **Getting Images into the TuriCreate framework**\n",
+    "Getting images into the Turi Create to build a model off of, whether that be an image classifer, image similarity or style transfer model, can be very easy, if you work within the Turi Create framework a certain way. To show you how to do this with your data, we used the popular CIFAR-10 dataset which can be downloaded [here](https://www.cs.toronto.edu/~kriz/cifar.html). Make sure to download the python batches. \n",
     "\n",
     "**TL;DR** Turi Create likes to load images from a directory where you pass the directory to the function `tc.load_images('directory_name')`. "
    ]


### PR DESCRIPTION
In this pull request:
- updated the README to include some functions for going beyond just the model building
- added the `images_in_turicreate.ipynb` notebook to detail how Turi Create likes to handle image data.